### PR TITLE
Handle potential nulls in JSON

### DIFF
--- a/cpa-ios-tests/Resources/Stubs/refresh_token_json_with_null/request
+++ b/cpa-ios-tests/Resources/Stubs/refresh_token_json_with_null/request
@@ -1,0 +1,9 @@
+POST /token HTTP/1.1
+Content-Type: application/json
+Cookie: connect.sid=s%3AbzgzHy8clX2mpXWtWNeHy8Zf.J52kzqBv6yIpVmULUoR8j7ARNNDUgssq0ZFIGu6uUzQ
+Host: cpa.rts.ch
+Connection: close
+User-Agent: Paw/2.1.1 (Macintosh; OS X/10.10.3) GCDHTTPRequest
+Content-Length: 153
+
+{"grant_type":"http://tech.ebu.ch/cpa/1.0/client_credentials","client_id":"407","client_secret":"f9f1c336a59219e05a59eecb40eb49eb","domain":"cpa.rts.ch"}

--- a/cpa-ios-tests/Resources/Stubs/refresh_token_json_with_null/response
+++ b/cpa-ios-tests/Resources/Stubs/refresh_token_json_with_null/response
@@ -1,0 +1,18 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Fri, 17 Apr 2015 13:25:49 GMT
+Content-Type: application/json; charset=utf-8
+Content-Length: 221
+Connection: close
+X-Powered-By: Express
+Cache-Control: no-store
+Pragma: no-cache
+
+{
+  "access_token": null,
+  "token_type": null,
+  "expires_in": null,
+  "domain": null,
+  "domain_display_name": null,
+  "user_name": null
+}

--- a/cpa-ios-tests/Sources/Tests/CPAStatelessRequestTestCase.m
+++ b/cpa-ios-tests/Sources/Tests/CPAStatelessRequestTestCase.m
@@ -441,4 +441,28 @@ static NSTimeInterval kConnectionTimeOut = 60;
     }];
 }
 
+- (void)testRefreshTokenJSONWithNull
+{
+    [HTTPStub installStubWithName:@"refresh_token_json_with_null"];
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Refresh token (JSON With Null)"];
+    NSURL *authorizationProviderURL = [NSURL URLWithString:@"https://cpa.rts.ch"];
+    
+    [CPAStatelessRequest refreshTokenWithAuthorizationProviderURL:authorizationProviderURL clientIdentifier:@"407" clientSecret:@"f9f1c336a59219e05a59eecb40eb49eb" domain:@"cpa.rts.ch" completionBlock:^(NSString *userName, NSString *accessToken, NSString *tokenType, NSString *domainName, NSInteger expiresInSeconds, NSError *error) {
+        XCTAssertNil(error);
+        
+        XCTAssertNil(userName);
+        XCTAssertNil(accessToken);
+        XCTAssertNil(tokenType);
+        XCTAssertNil(domainName);
+        XCTAssertEqual(expiresInSeconds, 0);
+        
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:kConnectionTimeOut handler:^(NSError *error) {
+        XCTAssertNil(error);
+    }];
+}
+
 @end

--- a/cpa-ios/Sources/NSURLConnection+CPAExtensions.m
+++ b/cpa-ios/Sources/NSURLConnection+CPAExtensions.m
@@ -28,14 +28,19 @@
             return;
         }
         
-        id responseJSON = [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL];
+        id responseJSON = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers error:NULL];
         if (! responseJSON || ! [responseJSON isKindOfClass:[NSDictionary class]]) {
             NSError *parsingError = CPAErrorFromCode(CPAErrorInvalidResponse);
             completionHandler ? completionHandler(nil, response, parsingError) : nil;
             return;
         }
         
-        NSDictionary *responseDictionary = responseJSON;
+        NSMutableDictionary *responseDictionary = responseJSON;
+        [[responseDictionary copy] enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+            if (obj == [NSNull null]) {
+                [responseDictionary removeObjectForKey:key];
+            }
+        }];
         
         // Deal with errors which might have been returned in the response JSON
         NSString *errorIdentifier = responseDictionary[@"error"] ?: responseDictionary[@"reason"];


### PR DESCRIPTION
I don’t know the CPA protocol enough, but probably an error should be returned when this happens instead of returning nil values and a nil error.
